### PR TITLE
fix: `post_process` applied twice causing date-time value parsing errors

### DIFF
--- a/tap_callminer/streams.py
+++ b/tap_callminer/streams.py
@@ -233,8 +233,7 @@ class DataTypeStream(CallMinerStream):
         )
 
         with gzip.open(filepath, "r") as f:
-            for record in csv.DictReader(line.decode("utf-8-sig") for line in f):
-                yield self.post_process(record)
+            yield from csv.DictReader(line.decode("utf-8-sig") for line in f)
 
     @override
     def post_process(self, row, context=None):


### PR DESCRIPTION
We recently updated to a [new SDK version](#5), which now applies the `post_process` method automatically for streams. This caused our `post_process` logic to be applied twice
1. once in manual `get_records` override
2. once by the SDK "automatically"

, resulting in the error:

```
ValueError: time data '2025-04-04T13:22:00+00:00' does not match format '%m/%d/%Y %H:%M:%S
```

