### PR TITLE
fix: Don't fail sync on export job cleanup error

### DIFF
--- a/tap_callminer/client.py
+++ b/tap_callminer/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from requests.adapters import HTTPAdapter, Retry
 from singer_sdk.helpers._typing import TypeConformanceLevel
 from singer_sdk.streams import RESTStream
 from typing_extensions import override
@@ -21,6 +22,62 @@ class CallMinerStream(RESTStream):
     def region(self):
         """Parse API region enum value from config."""
         return CallMinerAPIRegion[self.config["region"]]
+
+    @override
+    @cached_property
+    def requests_session(self):
+        # An export job leaves this pool idle for as long as the download and
+        # downstream processing take - hours, for a large export - by which point
+        # intermediaries have usually dropped the socket without sending a FIN, so
+        # urllib3's own liveness check can't spot it. Retrying at the transport layer
+        # gets a fresh connection. Only idempotent methods are retried by default, so
+        # the job-creating POST is never replayed. Status-based retries are left to
+        # `validate_response` and the SDK's backoff handling.
+        session = super().requests_session
+        adapter = HTTPAdapter(max_retries=Retry(total=3, backoff_factor=1))
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
+
+    @cached_property
+    def _send_with_retries(self):
+        # `request_decorator` is what supplies retry and backoff; the SDK only applies
+        # it to `_request` from within `request_records`, so requests made outside the
+        # record flow get no backoff unless they wrap themselves.
+        #
+        # Deliberately not reusing `_request`: it logs metrics against `self.path`,
+        # which the data type streams have no reason to define, and which would
+        # mislabel these calls on the streams that do. Re-applying the authenticator
+        # per attempt is what lets a retry recover from a token that expired while a
+        # long export was in flight.
+        def send(prepared_request):
+            response = self.requests_session.send(
+                self.authenticator(prepared_request),
+                timeout=self.timeout,
+                allow_redirects=self.allow_redirects,
+            )
+            self.validate_response(response)
+            return response
+
+        return self.request_decorator(send)
+
+    def send_request(self, method, url, **kwargs):
+        """Make a request outside the paginated record flow.
+
+        Applies the same retry, backoff and response validation the SDK gives to
+        record requests.
+
+        Args:
+            method: HTTP method.
+            url: Fully qualified URL.
+            kwargs: Additional arguments for :class:`requests.Request`.
+
+        Returns:
+            The validated :class:`requests.Response`.
+        """
+        return self._send_with_retries(
+            self.build_prepared_request(method=method, url=url, **kwargs),
+        )
 
     @override
     @cached_property

--- a/tap_callminer/streams.py
+++ b/tap_callminer/streams.py
@@ -172,30 +172,32 @@ class ExportStream(CallMinerStream):
                 self.stream_state["start_date"] = job_execution["CreateDate"]
 
         finally:
-            self.logger.info("Cleaning up job %s", job_id)
-
-            response = self.requests_session.send(
-                self.build_prepared_request(
-                    method="DELETE",
-                    url=f"{self.url_base}/export/job/{job_id}",
-                ),
-                timeout=self.timeout,
-                allow_redirects=self.allow_redirects,
-            )
-            response.raise_for_status()
+            self._cleanup(f"job {job_id}", f"{self.url_base}/export/job/{job_id}")
 
             if job_execution_id:
-                self.logger.info("Cleaning up job execution %s", job_execution_id)
-
-                response = self.requests_session.send(
-                    self.build_prepared_request(
-                        method="DELETE",
-                        url=f"{self.url_base}/export/history/{job_execution_id}",
-                    ),
-                    timeout=self.timeout,
-                    allow_redirects=self.allow_redirects,
+                self._cleanup(
+                    f"job execution {job_execution_id}",
+                    f"{self.url_base}/export/history/{job_execution_id}",
                 )
-                response.raise_for_status()
+
+    def _cleanup(self, description: str, url: str):
+        """Delete a server-side export resource, best-effort.
+
+        Failures are logged rather than raised. By the time cleanup runs the records
+        have already been emitted, so letting a housekeeping call fail the stream
+        would discard a completed sync - and, raising from a `finally`, would mask
+        whatever genuine error was already on its way out.
+
+        Args:
+            description: Resource description, for logging.
+            url: Resource URL to delete.
+        """
+        self.logger.info("Cleaning up %s", description)
+
+        try:
+            self.send_request(method="DELETE", url=url)
+        except Exception:
+            self.logger.warning("Failed to clean up %s", description, exc_info=True)
 
 
 class DataTypeStream(CallMinerStream):


### PR DESCRIPTION
Treat export job cleanup as best-effort and retry dropped connections so a completed sync isn't failed by its own tidy-up